### PR TITLE
Implementing integration tests with jest and supertest

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
-
 {
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "scripts": {
     "build": "babel src -d dist",
-    "prod": "node dist/app.js",
-    "dev": "nodemon --exec babel-node src/app.js",
+    "prod": "node dist/server.js",
+    "dev": "nodemon --exec babel-node src/server.js",
     "migrations": "node src/utils/migrations.js",
-    "test:unit": "cross-env NODE_ENV=test jest --testPathPattern=src/tests/unit/ --testTimeout=10000"
+    "test:unit": "cross-env NODE_ENV=test jest --testPathPattern=src/tests/unit/ --testTimeout=10000",
+    "test:integration": "cross-env NODE_ENV=test jest --testPathPattern=src/tests/integration/ --testTimeout=10000 --detectOpenHandles"
   },
   "keywords": [],
   "author": "WWC Medellín",
@@ -23,7 +24,8 @@
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "supertest": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.5",

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,6 @@ import { AuthRouter } from './router/auth.router.js';
 import { applyJWTAuthentication } from './middlewares/auth.middleware.js';
 import './utils/passport.config.js'; // Your Passport configuration
 
-const PORT = process.env.PORT || 3001;
 const app = express();
 
 app.use(cors());
@@ -21,6 +20,4 @@ app.use('/groups', GroupRouter().registerRoutes());
 app.use('/users', UserRouter().registerRoutes());
 app.use('/auth', AuthRouter().registerRoutes());
 
-app.listen(PORT, () => {
-  console.log(`Express server running on port http://localhost:${PORT} 🚀`);
-});
+export default app;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,9 @@
+import app from './app.js';
+
+const PORT = process.env.PORT || 3001;
+
+app.listen(PORT, () => {
+  console.log(`Express server running on port http://localhost:${PORT} 🚀`);
+});
+
+export default app;

--- a/src/tests/integration/groups.test.js
+++ b/src/tests/integration/groups.test.js
@@ -1,0 +1,115 @@
+import supertest from 'supertest';
+import app from '../../app.js';
+import { login } from '../utils.js';
+
+const requestWithSupertest = supertest(app);
+
+const URL = '/groups';
+let token = null;
+
+describe('Groups endpoints', () => {
+  beforeAll(async () => {
+    token = await login(requestWithSupertest);
+  });
+
+  describe('GET /groups', () => {
+    it('should return 401 when no bearer token is provided', async () => {
+      const res = await requestWithSupertest.get(URL);
+
+      expect(res.status).toEqual(401);
+    });
+
+    it('should return 200 when bearer token is provided', async () => {
+      const res = await requestWithSupertest.get(URL).set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(200);
+    });
+  });
+
+  describe('GET /groups/{id}', () => {
+    it('should return 401 when no bearer token is provided', async () => {
+      const res = await requestWithSupertest.get(`${URL}/1`);
+
+      expect(res.status).toEqual(401);
+    });
+
+    it('should return 404 when bearer token is provided but the group was not found', async () => {
+      const res = await requestWithSupertest
+        .get(`${URL}/100`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(404);
+    });
+
+    it('should return 200 when bearer token is provided and id is found', async () => {
+      const res = await requestWithSupertest
+        .get(`${URL}/1`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(200);
+    });
+  });
+
+  describe('PUT /groups/{id}', () => {
+    it('should return 401 when no bearer token is provided', async () => {
+      const res = await requestWithSupertest.put(`${URL}/1`);
+
+      expect(res.status).toEqual(401);
+    });
+
+    it('should return 400 when bearer token is provided but the body is not valid', async () => {
+      const res = await requestWithSupertest
+        .put(`${URL}/1`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(400);
+      expect(res.body).toBeDefined();
+      expect(res.body.messages.length).not.toBe(0);
+    });
+
+    it('should return 404 when bearer token is provided but the provided id does not exist', async () => {
+      const body = {
+        name: 'test',
+        color: '#FFF',
+      };
+      const res = await requestWithSupertest
+        .put(`${URL}/100`)
+        .send(body)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(404);
+    });
+
+    it('should return 200 when bearer token is provided and group was updated successfully', async () => {
+      const body = {
+        name: 'test',
+        color: '#FFF',
+      };
+      const res = await requestWithSupertest
+        .put(`${URL}/1`)
+        .send(body)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(200);
+      expect(res.body).toBeDefined();
+      expect(res.body.group).toBeDefined();
+      expect(res.body.group.color).toBe(body.color);
+    });
+  });
+
+  describe('DELETE /groups/{id}', () => {
+    it('should return 401 when no bearer token is provided', async () => {
+      const res = await requestWithSupertest.delete(`${URL}/1`);
+
+      expect(res.status).toEqual(401);
+    });
+
+    it('should return 404 when bearer token is provided but the provided id does not exist', async () => {
+      const res = await requestWithSupertest
+        .delete(`${URL}/100`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toEqual(404);
+    });
+  });
+});

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,0 +1,11 @@
+export const login = async (requestWithSupertest) => {
+  const loginResponse = await requestWithSupertest.post('/auth/login').send({
+    email: 'sisas@sisas.com',
+    password: 'sisas',
+  });
+
+  expect(loginResponse.status).toEqual(200);
+  expect(loginResponse.body.token).toBeDefined();
+
+  return loginResponse.body.token;
+};


### PR DESCRIPTION
Integration tests folder and steps:

**Dependencies/installation**

- `npm install supertest`
- Updating the package with a new script only to run integration tests
- Splitting `app.js` into `app.js` and `server.js` in order to let supertest manage the start/stop for the development server

**Running the tests**

- Make sure the database is up and running
- Confirm the credentials you use for login into the app (check src/tests/utils.js)
- To execute simply run `npm run test:integration`
